### PR TITLE
Call to PostTimedTask fails on Windows (x86_64) in HostSample and NodeSample

### DIFF
--- a/samples/HostSample/ChakraCoreHostMainData.pas
+++ b/samples/HostSample/ChakraCoreHostMainData.pas
@@ -101,7 +101,7 @@ var
   DataModule: TDataModuleMain absolute CallbackState;
   AMessage: TTaskMessage;
   Delay: Cardinal;
-  FuncArgs: array[0..0] of JsValueRef;
+  FuncArgs: array of JsValueRef;
   I: Integer;
 begin
   Result := JsUndefinedValue;
@@ -116,6 +116,7 @@ begin
 
   if ArgCount >= 4 then
   begin
+    SetLength(FuncArgs, ArgCount - 3);
     for I := 0 to ArgCount - 4 do
       FuncArgs[I] := Args^[I + 3];
   end;

--- a/samples/NodeSample/NodeMainData.pas
+++ b/samples/NodeSample/NodeMainData.pas
@@ -147,7 +147,7 @@ var
   DataModule: TDataModuleMain absolute CallbackState;
   AMessage: TTaskMessage;
   Delay: Cardinal;
-  FuncArgs: array[0..0] of JsValueRef;
+  FuncArgs: array of JsValueRef;
   I: Integer;
 begin
   Result := JsUndefinedValue;
@@ -162,6 +162,7 @@ begin
 
   if ArgCount >= 4 then
   begin
+    SetLength(FuncArgs, ArgCount - 3);
     for I := 0 to ArgCount - 4 do
       FuncArgs[I] := Args^[I + 3];
   end;

--- a/samples/WasmSample/WasmMainData.pas
+++ b/samples/WasmSample/WasmMainData.pas
@@ -168,29 +168,26 @@ var
   DataModule: TDataModuleMain absolute CallbackState;
   AMessage: TTaskMessageEx;
   Delay: Cardinal;
-  FuncArgs: JsValueRefArray;
+  FuncArgs: array of JsValueRef;
+  I: Integer;
 begin
   Result := JsUndefinedValue;
   if DataModule.FTerminated then
     Exit;
 
-  // arg 0: thisarg
-  // arg 1: task
-  if ArgCount < 2 then
+  if ArgCount < 2 then // thisarg, function to call, optional: delay, function args
     raise Exception.Create('Invalid arguments');
 
-  // arg 2: (optional) delay
   if ArgCount >= 3 then
     Delay := JsNumberToInt(Args^[2])
   else
     Delay := 0;
 
-  // arg 3...: (optional) function args
-  FuncArgs := nil;
   if ArgCount >= 4 then
   begin
     SetLength(FuncArgs, ArgCount - 3);
-    Move(Args^[3], FuncArgs[0], (ArgCount - 3) * SizeOf(JsValueRef));
+    for I := 0 to ArgCount - 4 do
+      FuncArgs[I] := Args^[I + 3];
   end;
 
   AMessage := TTaskMessageEx.Create(DataModule.FContext, Args^[1], Args^[0], FuncArgs, Delay, RepeatCount);


### PR DESCRIPTION
See the following issue: https://github.com/tondrej/chakracore-delphi/issues/20

The bug did not affect the `PostTimedTask` method in the `WasmSample` project, but I still modified it for consistency.

The fix was tested on:
- Windows (i386) through Delphi 10.1 Berlin and Free Pascal 3.2.2 compilers
- Windows (x86_64) through Delphi 10.1 Berlin and Free Pascal 3.2.2 compilers
- Linux through Free Pascal 3.2.2 compiler
- Darwin through Free Pascal 3.2.2 compiler